### PR TITLE
Add support for GeoLocation, fallback on hardcoded Trondheim lookup

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -19,7 +19,7 @@ app.use(function(req, res, next) {
 
 
 app.get('/', function(req, res) {
-  weatherData(function(error, data) {
+  weatherData.getWeatherData(function(error, data) {
     if (error) {
       res.status(500).end();
     } else {
@@ -41,7 +41,17 @@ app.get('/', function(req, res) {
 });
 
 app.get('/forecast/', function(req, res) {
-  weatherData(function(error, data) {
+  weatherData.getWeatherData(function(error, data) {
+    if (error) {
+      res.status(500).end();
+    } else {
+      res.send(data);
+    }
+  });
+});
+
+app.get('/forecast/:lat/:long/', function(req, res) {
+  weatherData.getWeatherDataByCoords(req.params.lat, req.params.long, function(error, data) {
     if (error) {
       res.status(500).end();
     } else {

--- a/api/weather-data.js
+++ b/api/weather-data.js
@@ -1,7 +1,7 @@
 var libxmljs = require('libxmljs');
 var request = require('request');
 
-module.exports = getWeatherData;
+module.exports.getWeatherData = getWeatherData;
 
 function getWeatherData(callback) {
   var url = 'http://www.yr.no/stad/Noreg/Sør-Trøndelag/Trondheim/Trondheim/varsel.xml';
@@ -31,6 +31,47 @@ function getWeatherData(callback) {
       };
 
       callback(null, weatherData);
+    }
+  });
+}
+
+module.exports.getWeatherDataByCoords = getWeatherDataByCoords;
+
+function getWeatherDataByCoords(lat, long, callback) {
+  var url = 'http://api.met.no/weatherapi/locationforecast/1.9/?lat=' + lat + ';lon=' + long;
+  request(url, function(error, response, body) {
+    if (error) {
+      callback(error);
+    } else if (response.statusCode != 200) {
+      callback(new Error(response.statusCode));
+    } else {
+      var xmlDoc = libxmljs.parseXml(body);
+
+      var currentTimePeriod = xmlDoc.get('//product/time/location');
+
+      var temperature = currentTimePeriod.get('temperature/@value').value();
+      var windSpeed = currentTimePeriod.get('windSpeed/@mps').value();
+      var effectiveTemperature = 13.12 +
+                                 0.6215 * temperature -
+                                 11.37 * Math.pow(windSpeed, 0.16) +
+                                 0.3965 * temperature * Math.pow(windSpeed, 0.16);
+
+      // Symbols are weird in the met.no API
+      // The first time data-point doesn't seem to have symbol data,
+      // but the next one usually does.
+      var symbol = xmlDoc.get('//product/time/location/symbol/@number').value();
+
+
+      var weatherData = {
+        temperature: Math.round(temperature),
+        effectiveTemperature: Math.round(effectiveTemperature),
+        windSpeed: windSpeed,
+        windDirection: currentTimePeriod.get('windDirection/@name').value(),
+        symbol: symbol
+      };
+
+      callback(null, weatherData);
+
     }
   });
 }

--- a/scripts.js
+++ b/scripts.js
@@ -1,12 +1,10 @@
 (function(window) {
-  // Symbol numbers documented here:
-  // http://om.yr.no/forklaring/symbol/
-  var rainNumbers = [40, 5, 41, 24, 6, 25, 42, 7, 43, 26, 20, 27, 46, 9, 10, 30, 22, 11, 47, 12, 48, 31, 23, 32];
-  var snowNumbers = [44, 8, 45, 28, 21, 29, 49, 13, 50, 33, 14, 34];
-
-  var url = '/api/forecast/';
-  $.getJSON(url, function(data) {
+  function isItShortsWeather(data) {
     var shortsWeather = false;
+    // Symbol numbers documented here:
+    // http://om.yr.no/forklaring/symbol/
+    var rainNumbers = [40, 5, 41, 24, 6, 25, 42, 7, 43, 26, 20, 27, 46, 9, 10, 30, 22, 11, 47, 12, 48, 31, 23, 32];
+    var snowNumbers = [44, 8, 45, 28, 21, 29, 49, 13, 50, 33, 14, 34];
 
     // Effective temperature above 15 and sunny
     if (data.effectiveTemperature >= 15 && data.symbol > 0 && data.symbol <= 3) {
@@ -33,5 +31,25 @@
         $('body').addClass('snow-weather');
       }
     }
-  });
+  }
+
+  function success(pos) {
+    var url = '/api/forecast/'
+          + pos.coords.latitude +'/'
+          + pos.coords.longitude + '/';
+    $.getJSON(url, isItShortsWeather);
+  }
+
+  function error(err) {
+    var url = '/api/forecast/';
+    $.getJSON(url, isItShortsWeather);
+  }
+
+  var options = {
+    enableHighAccuracy: true,
+    timeout: 5000,
+    maximumAge: 0
+  };
+
+  navigator.geolocation.getCurrentPosition(success, error, options)
 })(window);


### PR DESCRIPTION
The [met.no](http://api.met.no/weatherapi/locationforecast/1.9/documentation) API is similar to that used by yr.no, with the added benefit of coordinate-based lookup.
By using `navigator.geolocation`, everyone (in Norway) can enjoy shortsdag.no.
