### PR TITLE
Use background-size: cover for background images

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,7 @@ html {
     height: 100%;
 }
 body {
+    background: transparent no-repeat center;
     background-size: cover;
     min-height: 100%;
     color: white;
@@ -20,15 +21,15 @@ body {
 }
 
 body.shorts-weather {
-    background: url('images/bg_shorts.jpg') no-repeat center;
+    background-image: url('images/bg_shorts.jpg');
 }
 body.cold-weather {
-    background: url('images/bg_cold.jpg') no-repeat center;
+    background-image: url('images/bg_cold.jpg');
 }
 body.rain-weather {
-    background: url('images/bg_rain.jpg') no-repeat center;
+    background-image: url('images/bg_rain.jpg');
 }
 body.snow-weather {
-    background: url('images/bg_snow.jpg') no-repeat center;
+    background-image: url('images/bg_snow.jpg');
     text-shadow: 0 0 5px #000;
 }


### PR DESCRIPTION
The background image was previously cover-sized, but this is no longer
the case. cdccd78c650493c6f488217545933e03a2bb0235 introduced multiple
background images, and in the process removed `background-size: cover`.
This commit restores cover sizing.

---

Before:

![image](https://cloud.githubusercontent.com/assets/578029/15164195/893e3f56-170d-11e6-8cef-3066849c593e.png)

---

After:

![image](https://cloud.githubusercontent.com/assets/578029/15164215/9d834d1c-170d-11e6-90a5-7759e6ca714f.png)
