### PR TITLE
Cast data.symbol to a Number when doing lookups

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -24,10 +24,10 @@
       if ((data.symbol > 0 && data.symbol <= 4) || data.symbol == 15) {
         $('body').addClass('cold-weather');
       }
-      if (rainNumbers.indexOf(data.symbol) !== -1) {
+      if (rainNumbers.indexOf(+data.symbol) !== -1) {
         $('body').addClass('rain-weather');
       }
-      if (snowNumbers.indexOf(data.symbol) !== -1) {
+      if (snowNumbers.indexOf(+data.symbol) !== -1) {
         $('body').addClass('snow-weather');
       }
     }


### PR DESCRIPTION
The numerical `symbol` attribute returned from the api is used to switch
body styles based on what type of weather it is (rain, snow, etc).
However, the attribute is a string-representation of a Number and not a
Number, so the indexOf-powered table lookups do not work correctly. This
commit adds type conversion to the symbol attribute via the unary plus
operator when it is used as an argument to indexOf. The end result is
that body styles are now properly applied for rainy and snowy days.
